### PR TITLE
Add support for private key in base64 encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ The `git` driver works by modifying a file in a repository with every bump. The
 
 * `private_key`: *Optional.* The SSH private key to use when pulling from/pushing to to the repository.
 
+* `private_key_base64`: *Optional.* Decode the private key from base64 format.
+   Useful for credential stores that do not support multi-line encrypted strings like AWS SSM Parameter Store.
+
 * `username`: *Optional.* Username for HTTP(S) auth when pulling/pushing.
    This is needed when only HTTP/HTTPS protocol for git is available (which does not support private key auth)
    and auth is required.

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -91,13 +91,14 @@ func FromSource(source models.Source) (Driver, error) {
 		return &GitDriver{
 			InitialVersion: initialVersion,
 
-			URI:        source.URI,
-			Branch:     source.Branch,
-			PrivateKey: source.PrivateKey,
-			Username:   source.Username,
-			Password:   source.Password,
-			File:       source.File,
-			GitUser:    source.GitUser,
+			URI:              source.URI,
+			Branch:           source.Branch,
+			PrivateKey:       source.PrivateKey,
+			PrivateKeyBase64: source.PrivateKeyBase64,
+			Username:         source.Username,
+			Password:         source.Password,
+			File:             source.File,
+			GitUser:          source.GitUser,
 		}, nil
 
 	case models.DriverSwift:

--- a/driver/git.go
+++ b/driver/git.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"encoding/base64"
 
 	"github.com/blang/semver"
 	"github.com/concourse/semver-resource/version"
@@ -29,14 +30,15 @@ func init() {
 type GitDriver struct {
 	InitialVersion semver.Version
 
-	URI        string
-	Branch     string
-	PrivateKey string
-	Username   string
-	Password   string
-	File       string
-	GitUser    string
-	Depth      string
+	URI              string
+	Branch           string
+	PrivateKey       string
+	PrivateKeyBase64 bool
+	Username         string
+	Password         string
+	File             string
+	GitUser          string
+	Depth            string
 }
 
 func (driver *GitDriver) Bump(bump version.Bump) (semver.Version, error) {
@@ -207,9 +209,21 @@ func (driver *GitDriver) setUpKey() error {
 	_, err := os.Stat(privateKeyPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			err := ioutil.WriteFile(privateKeyPath, []byte(driver.PrivateKey), 0600)
-			if err != nil {
-				return err
+		    if driver.PrivateKeyBase64 != true {
+			    err := ioutil.WriteFile(privateKeyPath, []byte(driver.PrivateKey), 0600)
+				if err != nil {
+					return err
+				}
+			} else {
+			    data, err := base64.StdEncoding.DecodeString(driver.PrivateKey)
+			    if err != nil {
+			        return err
+			    } else {
+			        err := ioutil.WriteFile(privateKeyPath, []byte(data), 0600)
+					if err != nil {
+						return err
+					}
+			    }
 			}
 		} else {
 			return err

--- a/models/models.go
+++ b/models/models.go
@@ -61,13 +61,14 @@ type Source struct {
 	ServerSideEncryption string `json:"server_side_encryption"`
 	UseV2Signing         bool   `json:"use_v2_signing"`
 
-	URI        string `json:"uri"`
-	Branch     string `json:"branch"`
-	PrivateKey string `json:"private_key"`
-	Username   string `json:"username"`
-	Password   string `json:"password"`
-	File       string `json:"file"`
-	GitUser    string `json:"git_user"`
+	URI              string `json:"uri"`
+	Branch           string `json:"branch"`
+	PrivateKey       string `json:"private_key"`
+	PrivateKeyBase64 bool   `json:"private_key_base64"`
+	Username         string `json:"username"`
+	Password         string `json:"password"`
+	File             string `json:"file"`
+	GitUser          string `json:"git_user"`
 
 	OpenStack OpenStackOptions `json:"openstack"`
 

--- a/test/check.sh
+++ b/test/check.sh
@@ -47,6 +47,21 @@ it_fails_if_key_has_password() {
   grep "private keys with passphrases are not supported" $failed_output
 }
 
+it_can_decode_base64_private_key() {
+  local repo=$(init_repo)
+
+  set_version $repo 1.2.3
+
+  local key=$TMPDIR/key-tmp
+  local key_base64=$TMPDIR/key-base64
+  ssh-keygen -f $key -N ""
+  base64 $key > $key_base64
+
+  check_uri_with_base64_key $repo $key_base64 | jq -e "
+    . == [{number: $(echo 1.2.3 | jq -R .)}]
+  "
+}
+
 it_can_check_with_credentials() {
   local repo=$(init_repo)
 
@@ -121,6 +136,7 @@ run it_can_check_with_no_current_version
 run it_can_check_with_no_current_version_with_initial_set
 run it_can_check_with_current_version
 run it_fails_if_key_has_password
+run it_can_decode_base64_private_key
 run it_can_check_with_credentials
 run it_can_check_from_a_version
 run it_clears_netrc_even_after_errors

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -100,6 +100,20 @@ check_uri_with_key() {
 }
 
 
+check_uri_with_base64_key() {
+  jq -n "{
+    source: {
+      driver: \"git\",
+      uri: $(echo $1 | jq -R .),
+      branch: \"master\",
+      file: \"some-file\",
+      private_key: $(cat $2 | jq -s -R .),
+      private_key_base64: true
+    }
+  }" | ${resource_dir}/check | tee /dev/stderr
+}
+
+
 check_uri_with_credentials() {
   jq -n "{
     source: {


### PR DESCRIPTION
SSM Parameter Store does not support multi-line encrypted strings.

- Add `private_key_base64` parameter to allow reading in a key that is base64 encoded.